### PR TITLE
Bugfix/assert near/inline

### DIFF
--- a/assert/array.hpp
+++ b/assert/array.hpp
@@ -3,6 +3,8 @@
 
 constexpr double default_tolerance = 1e-4;
 
+namespace assert{
+
 namespace {
 
     struct is_subtractable_impl {
@@ -48,4 +50,6 @@ inline bool assertNear(size_t arraySize, const ElemType *expected, const ElemTyp
     }
     return true;
 };
+
+}   // ~ namespace
 

--- a/assert/array.hpp
+++ b/assert/array.hpp
@@ -3,18 +3,22 @@
 
 constexpr double default_tolerance = 1e-4;
 
-struct is_subtractable_impl {
-    template <class T>
-    static auto check(T&& x)->decltype(x-x, std::true_type{});
-    template <class T>
-    static auto check(...)->std::false_type;
-};
+namespace {
 
-template <class T>
-struct is_subtractable : decltype(is_subtractable_impl::check<T>(std::declval<T>())){};
+    struct is_subtractable_impl {
+        template <class T>
+        static auto check(T&& x)->decltype(x-x, std::true_type{});
+        template <class T>
+        static auto check(...)->std::false_type;
+    };
+
+    template <class T>
+    struct is_subtractable : decltype(is_subtractable_impl::check<T>(std::declval<T>())){};
+
+}
 
 template <class ElemType, std::enable_if_t<is_subtractable<ElemType>::value, std::nullptr_t> = nullptr>
-bool assertNear(const ElemType& expected, const ElemType& actual, const double tolerance = default_tolerance){
+inline bool assertNear(const ElemType& expected, const ElemType& actual, const double tolerance = default_tolerance){
     if(std::abs(expected - actual) > tolerance){
         std::cerr << "\033[91m[Error]\033[0m Assertion failed (tolerance = " << tolerance << ")" << std::endl;
         std::cerr << "(expected) " << expected << " <> " << actual << " (actual)" << std::endl;
@@ -24,7 +28,7 @@ bool assertNear(const ElemType& expected, const ElemType& actual, const double t
 };
 
 template <class ElemType, size_t arraySize>
-bool assertNear(const ElemType (&expected)[arraySize], const ElemType (&actual)[arraySize], const double tolerance = default_tolerance){
+inline bool assertNear(const ElemType (&expected)[arraySize], const ElemType (&actual)[arraySize], const double tolerance = default_tolerance){
     for(size_t i=0; i<arraySize; ++i){
         if(!assertNear(expected[i], actual[i], tolerance)){
             std::cerr << "\t |> at index " << i << " / " << arraySize << std::endl;
@@ -35,7 +39,7 @@ bool assertNear(const ElemType (&expected)[arraySize], const ElemType (&actual)[
 };
 
 template <class ElemType>
-bool assertNear(size_t arraySize, const ElemType *expected, const ElemType *actual, const double tolerance = default_tolerance){
+inline bool assertNear(size_t arraySize, const ElemType *expected, const ElemType *actual, const double tolerance = default_tolerance){
     for(size_t i=0; i<arraySize; ++i){
         if(!assertNear(expected[i], actual[i], tolerance)){
             std::cerr << "\t |> at index " << i << " / " << arraySize << std::endl;

--- a/test.cpp
+++ b/test.cpp
@@ -3,6 +3,8 @@
 
 #include "assert/array.hpp"
 
+using namespace assert;
+
 void success(){
     std::cout << "\t-> \033[92mSuccess!\033[0m" << std::endl;
 }


### PR DESCRIPTION
関数を `assert` 名前空間に入れた。
複数の翻訳単位でincludeしても衝突しないようにした。